### PR TITLE
Fix path issue for when transform_path uses a full url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.10
+- Fix issue where setting a URL when overriding `transform_path` results in a `/` preceding the `http://`
+
 ## 0.2.9
 
 Fix gem dependencies to support Rails 5 #141

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -78,7 +78,7 @@ module Swagger
               resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config, ret[:klass].swagger_config)
               debased_path = get_debased_path(ret[:path], settings[:controller_base_path])
               resource_api = {
-                path: "/#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}",
+                path: "#{fixup_http_path(debased_path, api_version)}.{format}",
                 description: ret[:klass].swagger_config[:description]
               }
               root[:apis] << resource_api
@@ -90,6 +90,12 @@ module Swagger
         end
 
         private
+
+        def fixup_http_path(debased_path, api_version)
+          path = "#{Config.transform_path(trim_leading_slash(debased_path), api_version)}"
+          return path if path.match(/^https?:\/\//)
+          "/#{path}"
+        end
 
         def transform_spec_to_api_path(spec, controller_base_path, extension)
           api_path = spec.to_s.dup

--- a/lib/swagger/docs/version.rb
+++ b/lib/swagger/docs/version.rb
@@ -1,5 +1,5 @@
 module Swagger
   module Docs
-    VERSION = "0.2.9"
+    VERSION = "0.2.10"
   end
 end


### PR DESCRIPTION
  this should prevent api paths to have `/http://some-url.com/#{path}` and
  simply have `http://some-url.com/#{path}`
- version and changelog bump